### PR TITLE
fix: Error now throws string instead of object

### DIFF
--- a/src/httpsRequestPromisified.ts
+++ b/src/httpsRequestPromisified.ts
@@ -11,11 +11,12 @@ export default function httpsRequestPromisified(
       }
 
       result.on("data", (rawResponse: Buffer) => {
-        const body = JSON.parse(rawResponse.toString());
+        const responseString = rawResponse.toString();
+        const body = JSON.parse(responseString);
         if (body.data) {
           resolve(body.data);
         } else {
-          reject(new Error(body));
+          reject(new Error(responseString));
         }
       });
     });

--- a/src/tests/httpsRequestPromisified.test.ts
+++ b/src/tests/httpsRequestPromisified.test.ts
@@ -39,16 +39,19 @@ test("400 response throws error", async () => {
 
 // Graphql error
 const graphErrorHost = "graphError.example.com";
+const erroneousResponse = {
+  errors: [{ name: "error1" }],
+};
+const errorneousBuffer = Buffer.from(JSON.stringify(erroneousResponse));
+
 nock(`https://${graphErrorHost}`)
   .post(testRequestObject.path)
-  .reply(200, {
-    errors: [{ name: "error1" }],
-  });
+  .reply(200, errorneousBuffer);
 test("400 response throws error", async () => {
   await expect(
     httpsRequestPromisified({
       ...testRequestObject,
       host: graphErrorHost,
     })
-  ).rejects.toThrow();
+  ).rejects.toThrow(errorneousBuffer.toString());
 });


### PR DESCRIPTION
Updated code and tests to correctly throw and assert the error message. 